### PR TITLE
Fix get_item_metadata: read from full item response

### DIFF
--- a/openhab_mcp/openhab_client.py
+++ b/openhab_mcp/openhab_client.py
@@ -487,15 +487,15 @@ class OpenHABClient:
         if not namespace:
             raise ValueError("Namespace must be provided")
 
-        response = self.session.get(
-            f"{self.base_url}/rest/items/{item_name}/metadata/{namespace}"
-        )
+        response = self.session.get(f"{self.base_url}/rest/items/{item_name}")
         if response.status_code == 404:
-            raise ValueError(
-                f"Item '{item_name}' or metadata namespace '{namespace}' not found"
-            )
+            raise ValueError(f"Item '{item_name}' not found")
         response.raise_for_status()
-        return response.json()
+
+        metadata = response.json().get("metadata", {}).get(namespace)
+        if metadata is None:
+            raise ValueError(f"Metadata namespace '{namespace}' not found for item '{item_name}'")
+        return metadata
 
     def add_or_update_item_metadata(
         self, item_name: str, namespace: str, metadata: ItemMetadata


### PR DESCRIPTION
## Summary

- Fixes `get_item_metadata` — openHAB has no `GET /rest/items/{item}/metadata/{namespace}` endpoint (returns 405)
- Instead fetches the full item via `GET /rest/items/{item}` and extracts the requested namespace from the `metadata` field
- Raises `ValueError` if the namespace is not present

## Test plan

- [ ] Call `get_item_metadata("vacuum_livingroom_segment", "stateDescription")` → returns `{"value": " ", "config": {"options": "16=Esszimmer,..."}}`
- [ ] Call with unknown namespace → raises `ValueError`
- [ ] Call with unknown item → raises `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)