### PR TITLE
fix: update_item loses semantic tags when sending full item state to openHAB

### DIFF
--- a/openhab_mcp/openhab_client.py
+++ b/openhab_mcp/openhab_client.py
@@ -268,8 +268,20 @@ class OpenHABClient:
         payload.pop('semanticTags', None)
         payload.pop('nonSemanticTags', None)
 
-        # Merge: existing as base (with converted tags), updates on top
-        merged = {**existing_item, 'tags': existing_tags, **payload}
+        # Build a clean base with only writable item fields — spreading existing_item
+        # directly sends read-only fields (state, metadata, stateDescription, link, ...)
+        # which causes openHAB to drop or corrupt semantic tags.
+        clean_base: Dict[str, Any] = {
+            'name': existing_item['name'],
+            'type': existing_item['type'],
+            'tags': existing_tags,
+        }
+        for field in ('label', 'category', 'groupNames', 'unitSymbol', 'function', 'groupType'):
+            if field in existing_item and existing_item[field] is not None:
+                clean_base[field] = existing_item[field]
+
+        # Apply updates on top
+        merged = {**clean_base, **payload}
 
         # Only override tags if explicitly set in the update
         if tags_explicitly_set:


### PR DESCRIPTION
## Problem

When calling `update_item`, the existing item was spread into the PUT body via `{**existing_item, ...}`. This included read-only response fields like `state`, `metadata`, `stateDescription`, `link`, `lastState` etc.

OpenHAB drops semantic tags when those extra fields are present in the PUT body — likely because the `metadata.semantics` from the payload overrides the `tags` array.

## Fix

Build a clean PUT payload with only writable item fields (`type`, `label`, `category`, `groupNames`, `unitSymbol`, `function`, `groupType`). Tag merging from existing item still works correctly.

## Test

Before: calling `update_item` to change only `type` (e.g. `Number` → `Number:Temperature`) dropped all semantic tags.

After: semantic tags are preserved.