### PR TITLE
fix: get_semantic_tag with include_subtags=True causes Pydantic validation error

### DIFF
--- a/openhab_mcp/openhab_mcp_server.py
+++ b/openhab_mcp/openhab_mcp_server.py
@@ -9,7 +9,7 @@ connects to a real openHAB instance via its REST API.
 import os
 import sys
 import logging
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Union
 from pathlib import Path
 from dotenv import load_dotenv
 from pydantic import Field
@@ -886,14 +886,19 @@ def get_semantic_tag(
         False,
         description="Include subtags in the response",
     ),
-) -> Optional[Dict[str, Any]]:
+) -> Union[Optional[Dict[str, Any]], List[Dict[str, Any]]]:
     """
     Get a specific openHAB tag by uid.
 
     Args:
         tag_uid: UID of the tag to get details for
     """
-    return openhab_client.get_semantic_tag(tag_uid, include_subtags)
+    result = openhab_client.get_semantic_tag(tag_uid, include_subtags)
+    if result is None:
+        return None
+    if not include_subtags:
+        return result[0] if result else None
+    return result
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

- `get_semantic_tag` with `include_subtags=True` raised a Pydantic validation error: *Input should be a valid dictionary* — because the client method always returns `List[Dict]` but the tool declared `-> Optional[Dict[str, Any]]`
- Fix: unwrap the result in the tool — return a single `Dict` when `include_subtags=False`, return the full `List[Dict]` when `include_subtags=True`
- Add `Union` to typing imports

## Root cause

`openhab_client.get_semantic_tag()` always returns a list (even for a single tag lookup, it filters by UID and returns a list). The MCP server tool passed this list through directly, but Pydantic's output validation expected a dict.

## Test plan

- [ ] Call `get_semantic_tag(tag_uid="Equipment_Network", include_subtags=False)` → returns single dict
- [ ] Call `get_semantic_tag(tag_uid="Equipment_Network", include_subtags=True)` → returns list of dicts (tag + subtags)
- [ ] Call `get_semantic_tag(tag_uid="nonexistent")` → returns `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)