### PR TITLE
fix: run MCP server in foreground for stdio transport

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN pip install .
 # Set Python path
 ENV PYTHONPATH=/app:$PYTHONPATH
 
-# Run the MCP server in the background and keep the container alive
-CMD python -m openhab_mcp & \
-    tail -f /dev/null
+# Entrypoint: foreground for stdio, background+tail for HTTP
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+CMD ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ "$OPENHAB_MCP_TRANSPORT" = "stdio" ]; then
+    exec python -m openhab_mcp
+else
+    python -m openhab_mcp &
+    tail -f /dev/null
+fi


### PR DESCRIPTION
## Summary

- The previous `CMD` backgrounded the Python process and attached stdin/stdout to `tail -f /dev/null`
- In stdio transport mode (used by Teleport), MCP protocol messages went to `tail` — the server never saw them and never responded
- Adds `docker/entrypoint.sh` that detects `OPENHAB_MCP_TRANSPORT`:
  - `stdio` → `exec python -m openhab_mcp` (foreground, stdin/stdout wired directly to server)
  - anything else → previous behavior (`& tail -f /dev/null` for HTTP mode)

## Test plan

- [ ] Build image and run with `OPENHAB_MCP_TRANSPORT=stdio`, verify MCP initialize response on stdout
- [ ] Confirm HTTP mode still works (container stays alive, `/mcp/` endpoint responds)
- [ ] Deploy via Teleport and confirm `tsh mcp connect openhab-mcp` returns tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)