### PR TITLE
fix: update_item drops semantic tags due to Pydantic alias mismatch

### DIFF
--- a/openhab_mcp/openhab_client.py
+++ b/openhab_mcp/openhab_client.py
@@ -266,13 +266,13 @@ class OpenHABClient:
         # Handle semantic and non-semantic tags from update
         tags_explicitly_set = 'semanticTags' in payload or 'nonSemanticTags' in payload
         tags = []
-        if hasattr(item, 'semanticTags') and item.semanticTags:
+        if item.semantic_tags:
             all_tags = self.list_semantic_tags()
             for tag in all_tags:
-                if tag["uid"] in item.semanticTags:
+                if tag["uid"] in item.semantic_tags:
                     tags.append(tag["name"])
-        if hasattr(item, 'nonSemanticTags') and item.nonSemanticTags:
-            tags.extend(item.nonSemanticTags)
+        if item.non_semantic_tags:
+            tags.extend(item.non_semantic_tags)
 
         payload.pop('semanticTags', None)
         payload.pop('nonSemanticTags', None)

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -325,6 +325,22 @@ class TestOpenHABItems(ItemsTestBase):
         self.assertEqual(fetched_group["groupType"], "Dimmer")
         self.assertEqual(fetched_group["function"]["name"], "AVG")
 
+    def test_update_item_preserves_semantic_tags(self):
+        """Regression: update_item must send tags to openHAB when semanticTags is explicitly passed.
+        Bug was hasattr(item, 'semanticTags') always False because Pydantic stores as semantic_tags."""
+        self._register(FULL_ITEM)
+        self.session.put.return_value = resp(None, 200)
+
+        self.client.update_item(ItemUpdate(
+            name="TestItem_FullItem", type="Dimmer",
+            category="Light",
+            semanticTags=["Equipment_Lighting"],
+        ))
+
+        put_body = self.session.put.call_args[1]["json"]
+        self.assertIn("Lighting", put_body.get("tags", []),
+                      "PUT payload must include the semantic tag name when semanticTags is passed")
+
     def test_update_item_with_none_or_empty_values(self):
         initial = dict(DIMMER_ITEM,
             label="Test Item for Update", category="Light",


### PR DESCRIPTION
## Summary

- `update_item` was using `hasattr(item, 'semanticTags')` to check for explicit tags, but the Pydantic field is named `semantic_tags` (alias: `semanticTags`) — so `hasattr` always returned `False`
- As a result, any call to `update_item` with explicit `semanticTags` would set `tags = []` and send an empty list to openHAB, **erasing the item's semantic tags**
- Same bug affected `nonSemanticTags` / `non_semantic_tags`

## Fix

Use the correct Python attribute names (`item.semantic_tags`, `item.non_semantic_tags`) instead of the Pydantic aliases.

## Test

Added regression test `test_update_item_preserves_semantic_tags` that verifies the PUT payload sent to openHAB actually contains the semantic tag name when `semanticTags` is passed to `update_item`.

## Test plan

- [x] All 11 existing tests still pass
- [x] New regression test covers the fixed code path
- [x] Verified fix against live openHAB instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)